### PR TITLE
fix: conditional cases for no-dynamic-styling

### DIFF
--- a/plugin/src/rules/no-dynamic-styling.ts
+++ b/plugin/src/rules/no-dynamic-styling.ts
@@ -1,6 +1,7 @@
 import { type Rule, createRule } from '../utils'
 import { isPandaAttribute, isPandaProp } from '../utils/helpers'
 import {
+  isConditionalExpression,
   isIdentifier,
   isJSXExpressionContainer,
   isLiteral,
@@ -39,6 +40,14 @@ const rule: Rule = createRule({
         )
           return
 
+        // Conditional case: <Circle property={condition ? 'value1' : 'value2' } />
+        if (
+          isConditionalExpression(node.value.expression) &&
+          isLiteral(node.value.expression.consequent) &&
+          isLiteral(node.value.expression.alternate)
+        )
+          return
+
         // Don't warn for objects. Those are conditions
         if (isObjectExpression(node.value.expression)) return
 
@@ -56,6 +65,10 @@ const rule: Rule = createRule({
 
         // For syntax like: { property: `value that could be multiline` }
         if (isTemplateLiteral(node.value) && node.value.expressions.length === 0) return
+
+        // Conditional case: { property: condition ? 'value1' : 'value2' }
+        if (isConditionalExpression(node.value) && isLiteral(node.value.consequent) && isLiteral(node.value.alternate))
+          return
 
         // Don't warn for objects. Those are conditions
         if (isObjectExpression(node.value)) return

--- a/plugin/src/utils/nodes.ts
+++ b/plugin/src/utils/nodes.ts
@@ -36,3 +36,5 @@ export const isImportDeclaration = isNodeOfType(AST_NODE_TYPES.ImportDeclaration
 export const isImportSpecifier = isNodeOfType(AST_NODE_TYPES.ImportSpecifier)
 
 export const isProperty = isNodeOfType(AST_NODE_TYPES.Property)
+
+export const isConditionalExpression = isNodeOfType(AST_NODE_TYPES.ConditionalExpression)

--- a/plugin/tests/no-dynamic-styling.test.ts
+++ b/plugin/tests/no-dynamic-styling.test.ts
@@ -28,6 +28,22 @@ function App(){
   return <styled.div color='red.100' />;
 }`,
   },
+  {
+    code: javascript`
+import { css } from './panda/css';
+
+function App({ primary }){
+  return <div className={css({ background: primary ? 'green.300' : 'gray.100' })} />;
+}`,
+  },
+  {
+    code: javascript`
+import { Circle } from './panda/jsx';
+
+function App({ primary }){
+  return <Circle color={primary ? 'green.300' : 'gray.100' } />;
+}`,
+  },
 ]
 
 const invalids = [
@@ -64,6 +80,24 @@ import { styled } from './panda/jsx';
 function App(){
   const color = 'red.100';
   return <styled.div color={color} />;
+}`,
+  },
+  {
+    code: javascript`
+import { css } from './panda/css';
+
+function App({ primary }){
+  const color = 'gray.100';
+  return <div className={css({ background: primary ? 'green.300' : color })} />;
+}`,
+  },
+  {
+    code: javascript`
+import { Circle } from './panda/jsx';
+
+function App({ primary }){
+  const color = 'gray.100';
+  return <Circle color={primary ? 'green.300' : color } />;
 }`,
   },
 ]


### PR DESCRIPTION
This PR fixes conditional cases for  `no-dynamic-styling`.

These patterns are valid ([docs](https://panda-css.com/docs/guides/dynamic-styling#what-you-can-do))

```jsx
<div className={css({ background: primary ? 'green.300' : 'gray.100' })} />
<Circle color={primary ? 'green.300' : 'gray.100' } />
```