### PR TITLE
fix: false positive in array of object value

### DIFF
--- a/plugin/src/rules/no-dynamic-styling.ts
+++ b/plugin/src/rules/no-dynamic-styling.ts
@@ -79,9 +79,6 @@ const rule: Rule = createRule({
 
         // Don't warn for objects. Those are conditions
         if (isObjectExpression(node.value)) return
-        if (isArrayExpression(node.value)) {
-          return checkElements(node.value, context)
-        }
 
         if (!isPandaAttribute(node, context)) return
 

--- a/plugin/tests/no-dynamic-styling.test.ts
+++ b/plugin/tests/no-dynamic-styling.test.ts
@@ -35,6 +35,12 @@ function App(){
   return <styled.div color='red.100' />;
 }`,
   },
+  {
+    code: javascript`
+const foo = 'foo'
+const nonStyles = {bar: [foo]}
+`,
+  },
 ]
 
 const invalids = [


### PR DESCRIPTION
Fixes #150. The `isArrayExpression` check is duplicated, but seems probably not necessary before the `isPandaAttribute` check.
