### PR TITLE
feat(no-physical-properties): detect `textAlign` physical values like "left"/"right"

### DIFF
--- a/docs/rules/no-physical-properties.md
+++ b/docs/rules/no-physical-properties.md
@@ -30,6 +30,20 @@ function App(){
   return <Circle _hover={{  borderBottom: 'solid 1px' }} />;
 }
 ```
+```js
+
+import { css } from './panda/css';
+
+const styles = css({ textAlign: 'left' });
+```
+```js
+
+import { Box } from './panda/jsx';
+
+function App(){
+  return <Box textAlign={"right"} />;
+}
+```
 
 ✔️ Examples of **correct** code:
 ```js
@@ -51,6 +65,20 @@ import { Circle } from './panda/jsx';
 
 function App(){
   return <Circle _hover={{  borderBlockEnd: 'solid 1px' }} />;
+}
+```
+```js
+
+import { css } from './panda/css';
+
+const styles = css({ textAlign: 'start' });
+```
+```js
+
+import { Box } from './panda/jsx';
+
+function App(){
+  return <Box textAlign={"end"} />;
 }
 ```
 

--- a/plugin/src/utils/physical-properties.ts
+++ b/plugin/src/utils/physical-properties.ts
@@ -32,3 +32,12 @@ export const physicalProperties: Record<string, string> = {
   top: 'insetBlockStart',
   bottom: 'insetBlockEnd',
 }
+
+// Map of property names to their physical values and corresponding logical values
+export const physicalPropertyValues: Record<string, Record<string, string>> = {
+  // text-align physical values mapped to logical values
+  textAlign: {
+    left: 'start',
+    right: 'end',
+  },
+}

--- a/plugin/tests/no-physical-proeprties.test.ts
+++ b/plugin/tests/no-physical-proeprties.test.ts
@@ -28,6 +28,42 @@ function App(){
   return <Circle _hover={{  borderBlockEnd: 'solid 1px' }} />;
 }`,
   },
+
+  // textAlign with non-physical values - regular object literal
+  {
+    code: javascript`
+import { css } from './panda/css';
+
+const styles = css({ textAlign: 'start' })`,
+  },
+
+  {
+    code: javascript`
+import { css } from './panda/css';
+
+function App(){
+  return <div className={css({ textAlign: 'end' })} />;
+}`,
+  },
+
+  // textAlign with non-physical values - JSX expression container
+  {
+    code: javascript`
+import { Box } from './panda/jsx';
+
+function App(){
+  return <Box textAlign={"start"} />;
+}`,
+  },
+
+  {
+    code: javascript`
+import { Box } from './panda/jsx';
+
+function App(){
+  return <Box textAlign={"end"} />;
+}`,
+  },
 ]
 
 const invalids = [
@@ -53,6 +89,42 @@ import { Circle } from './panda/jsx';
 
 function App(){
   return <Circle _hover={{  borderBottom: 'solid 1px' }} />;
+}`,
+  },
+
+  // textAlign with physical values - regular object literal
+  {
+    code: javascript`
+import { css } from './panda/css';
+
+const styles = css({ textAlign: 'left' })`,
+  },
+
+  {
+    code: javascript`
+import { css } from './panda/css';
+
+function App(){
+  return <div className={css({ textAlign: 'right' })} />;
+}`,
+  },
+
+  // textAlign with physical values - JSX expression container
+  {
+    code: javascript`
+import { Box } from './panda/jsx';
+
+function App(){
+  return <Box textAlign={"left"} />;
+}`,
+  },
+
+  {
+    code: javascript`
+import { Box } from './panda/jsx';
+
+function App(){
+  return <Box textAlign={"right"} />;
 }`,
   },
 ]


### PR DESCRIPTION
## Overview

This PR enhances the `@pandacss/no-physical-properties` ESLint rule to detect physical 
CSS text alignment values and suggest logical alternatives.

## Changes

- Added detection for `textAlign: "left"` and `textAlign: "right"` (physical values)
- The rule now suggests using `textAlign: "start"` and `textAlign: "end"` (logical values)
- Created a reusable `physicalPropertyValues` map in `plugin/src/utils/physical-properties.ts`

## Motivation

Current rule does not report `textAlign: "left"` as error.
Instead of it, This PR fix to report it as error and suggest to use `textAlign: "start"`.

## Related Issues

Fixes: #242