### PR TITLE
perf: replace `WeakMap` caches with simple single-file cache

### DIFF
--- a/plugin/src/utils/helpers.ts
+++ b/plugin/src/utils/helpers.ts
@@ -79,15 +79,15 @@ export const isPandaConfigFunction = (context: RuleContext<any, any>, name: stri
  */
 class Cache<Data> {
   // Filename of file for which data is cached
-  currentFilename: string | null
+  private currentFilename: string | null
   // Data for file whose filename is `currentFilename`
-  currentData: Data | null
+  private currentData: Data | null
 
   // Whether a timer for resetting cache has been set
-  resetTimerSet: boolean
+  private resetTimerSet: boolean
 
   // Function to compute data for a file
-  compute: (context: RuleContext<any, any>) => Data
+  private readonly compute: (context: RuleContext<any, any>) => Data
 
   /**
    * Create cache.

--- a/plugin/src/utils/helpers.ts
+++ b/plugin/src/utils/helpers.ts
@@ -178,9 +178,9 @@ export const isPandaIsh = (name: string, context: RuleContext<any, any>) => {
   return syncAction('matchFile', getSyncOpts(context), name, imports)
 }
 
-const scopeAnalysisCache = new Cache(_analyseScope)
+const scopeAnalysisCache = new Cache(_analyzeScope)
 
-function _analyseScope(context: RuleContext<any, any>): ReturnType<typeof analyze> {
+function _analyzeScope(context: RuleContext<any, any>): ReturnType<typeof analyze> {
   return analyze(context.sourceCode.ast as TSESTree.Node, {
     sourceType: 'module',
   })

--- a/plugin/src/utils/helpers.ts
+++ b/plugin/src/utils/helpers.ts
@@ -115,7 +115,7 @@ class Cache<Data> {
 
     // Set timer to free data on next micro-tick, after this file has been linted
     if (!this.resetTimerSet) {
-      queueMicrotask(resetCache.bind(null, this))
+      queueMicrotask(this.reset.bind(this))
       this.resetTimerSet = true
     }
 
@@ -124,18 +124,19 @@ class Cache<Data> {
     this.currentData = data
     return data
   }
-}
 
-/**
- * Reset cache.
- * This function is a pure function, defined outside the Cache class, to avoid it acting as a closure
- * and hanging on to data which could otherwise be garbage collected.
- * @param cache - Cache to reset
- */
-function resetCache<T>(cache: Cache<T>) {
-  cache.currentFilename = null
-  cache.currentData = null
-  cache.resetTimerSet = false
+  /**
+   * Reset cache.
+   * The next time `get` is called, data will be recomputed.
+   *
+   * This is a separate method instead of an arrow function inline in `get` method,
+   * to avoid it capturing `context` in its closure, and preventing it being garbage collected.
+   */
+  private reset() {
+    this.currentFilename = null
+    this.currentData = null
+    this.resetTimerSet = false
+  }
 }
 
 const _getImports = (context: RuleContext<any, any>) => {

--- a/plugin/src/utils/helpers.ts
+++ b/plugin/src/utils/helpers.ts
@@ -65,6 +65,79 @@ export const isPandaConfigFunction = (context: RuleContext<any, any>, name: stri
   return imports.some(({ alias, mod }) => alias === name && mod === '@pandacss/dev')
 }
 
+/**
+ * Cache for data which is expensive to compute and can be reused while linting a file.
+ * This data can be shared across multiple rules.
+ *
+ * Only 1 file is linted at a time, so there's no need to store data for multiple files at the same time.
+ * This simple cache just holds the data for the current file. If `get` is called with `Context` of a different file,
+ * data for the new file will be computed and cached.
+ *
+ * For situations where the process is long-running (e.g. a language server), the cache will be cleared
+ * on the next micro-tick, to free the cached data and allow it to be garbage collected.
+ * This also ensures if the same file is linted again, it doesn't get stale data from the last run.
+ */
+class Cache<Data> {
+  // Filename of file for which data is cached
+  currentFilename: string | null
+  // Data for file whose filename is `currentFilename`
+  currentData: Data | null
+
+  // Whether a timer for resetting cache has been set
+  resetTimerSet: boolean
+
+  // Function to compute data for a file
+  compute: (context: RuleContext<any, any>) => Data
+
+  /**
+   * Create cache.
+   * @param compute - Function to compute data for a file
+   */
+  constructor(compute: (context: RuleContext<any, any>) => Data) {
+    this.currentFilename = null
+    this.currentData = null
+    this.resetTimerSet = false
+
+    this.compute = compute
+  }
+
+  /**
+   * Get data for the file currently being linted.
+   * If data for this file is already cached, return it.
+   * Otherwise, compute data and cache it.
+   * @param context - ESLint Context object
+   * @returns Data for the file
+   */
+  get(context: RuleContext<any, any>) {
+    if (context.filename === this.currentFilename) {
+      return this.currentData!
+    }
+
+    // Set timer to free data on next micro-tick, after this file has been linted
+    if (!this.resetTimerSet) {
+      queueMicrotask(resetCache.bind(null, this))
+      this.resetTimerSet = true
+    }
+
+    const data = this.compute(context)
+    this.currentFilename = context.filename
+    this.currentData = data
+    return data
+  }
+}
+
+/**
+ * Reset cache.
+ * This function is a pure function, defined outside the Cache class, to avoid it acting as a closure
+ * and hanging on to data which could otherwise be garbage collected.
+ * @param cache - Cache to reset
+ */
+function resetCache<T>(cache: Cache<T>) {
+  cache.currentFilename = null
+  cache.currentData = null
+  cache.resetTimerSet = false
+}
+
 const _getImports = (context: RuleContext<any, any>) => {
   const specifiers = getImportSpecifiers(context)
 
@@ -78,16 +151,15 @@ const _getImports = (context: RuleContext<any, any>) => {
 }
 
 // Caching imports per context to avoid redundant computations
-const importsCache = new WeakMap<RuleContext<any, any>, ImportResult[]>()
+const importsCache = new Cache(_getFilteredImports)
+
+function _getFilteredImports(context: RuleContext<any, any>): ImportResult[] {
+  const imports = _getImports(context)
+  return imports.filter((imp) => syncAction('matchImports', getSyncOpts(context), imp))
+}
 
 export const getImports = (context: RuleContext<any, any>) => {
-  if (importsCache.has(context)) {
-    return importsCache.get(context)!
-  }
-  const imports = _getImports(context)
-  const filteredImports = imports.filter((imp) => syncAction('matchImports', getSyncOpts(context), imp))
-  importsCache.set(context, filteredImports)
-  return filteredImports
+  return importsCache.get(context)
 }
 
 const isValidStyledProp = <T extends Node>(node: T, context: RuleContext<any, any>) => {
@@ -106,7 +178,13 @@ export const isPandaIsh = (name: string, context: RuleContext<any, any>) => {
   return syncAction('matchFile', getSyncOpts(context), name, imports)
 }
 
-const scopeAnalysisCache = new WeakMap<object, ReturnType<typeof analyze>>()
+const scopeAnalysisCache = new Cache(_analyseScope)
+
+function _analyseScope(context: RuleContext<any, any>): ReturnType<typeof analyze> {
+  return analyze(context.sourceCode.ast as TSESTree.Node, {
+    sourceType: 'module',
+  })
+}
 
 const findDeclaration = (name: string, context: RuleContext<any, any>) => {
   try {
@@ -117,13 +195,7 @@ const findDeclaration = (name: string, context: RuleContext<any, any>) => {
       return undefined
     }
 
-    let scope = scopeAnalysisCache.get(src)
-    if (!scope) {
-      scope = analyze(src.ast as TSESTree.Node, {
-        sourceType: 'module',
-      })
-      scopeAnalysisCache.set(src, scope)
-    }
+    const scope = scopeAnalysisCache.get(context)
 
     const decl = scope.variables
       .find((v) => v.name === name)


### PR DESCRIPTION
### The problem

This plugin caches 2 sets of information for each file in 2 x `WeakMap`s.

1. `importsCache` - keyed by `context` object passed to `rule.create`.
2. `scopeAnalysisCache` - keyed by `context.sourceCode`.

This presents 2 opportunities for optimization:

Firstly, `WeakMap`s in JS are fairly slow. It's ideal to avoid them if possible.

Secondly (and more significantly), the `context` object passed to each rule is different, so `importsCache` only caches per-rule per-file, not per-file. So it has a separate cache entry per rule - the cache is not shared between rules.

17 rules use `isRecipeVariant`, which calls `getImports`, which uses the cache. If the user has all 17 rules enabled, calculating the imports may happen 17 times per file, when it only needs to happen once.

### This PR

This PR replaces these 2 x `WeakMap`s with a simpler cache that holds only one piece of data at a time. It utilizes the fact that ESLint only lints one file at a time, and uses `filename` as the cache key.

To make sure this plugin also works correctly in an IDE/language server context, where the same file can be linted over and over again as the user types or saves the file, the cache is also cleared after a micro-tick. So even if the file is edited and linted again, the 2nd lint run won't get stale data from the previous run.

In ESLint run as CLI, the entire linting process runs synchronously, so `resetCache` will only run once at the very end of the entire linting process.

### My ulterior motive

I'm not a Panda user myself, and you may wonder why I'm here.

I'm one of the maintainers of [Oxlint](https://oxc.rs/docs/guide/usage/linter.html), and we received a bug report saying that this plugin does not work in Oxlint. Obviously we wanted to rectify that - we would like Oxlint to support Panda users!

The root cause of the problem using this plugin in Oxlint is that Oxlint re-uses the same `context` object over and over for each file. This is a performance optimization - we use object pooling wherever we can, as it reduces garbage collector pressure, leading to significantly faster lint times.

However, this makes `context` objects unsuitable to be used as `WeakMap` keys - because the key is the same for every file. So it breaks the cache in this plugin.

We'd prefer if at all possible to keep the object pooling optimization in Oxlint, so I thought I'd submit this PR to see if you'd be willing to consider altering the plugin to be Oxlint-compatible. As it happens, this change should also be a nice speed-up for the reasons discussed above (in *both* ESLint and Oxlint).

Here is the Oxlint issue, in case you're interested: https://github.com/oxc-project/oxc/issues/19986. Please note that much of the root cause analysis provided in that issue by the OP appears to be erroneous / AI confusion - we believe the real explanation is the `WeakMap` caches.