### PR TITLE
perf: replace `WeakMap` caches with faster mechanism

### DIFF
--- a/plugin/src/utils/cache.ts
+++ b/plugin/src/utils/cache.ts
@@ -1,0 +1,60 @@
+import { type analyze } from '@typescript-eslint/scope-manager'
+import { type ImportResult } from '.'
+
+// Cache for data which is expensive to compute and can be reused while linting a file.
+// This data is shared across multiple rules.
+// Cache is cleared after linting each file (see `ruleFinished` below).
+export const cache: {
+  // Cached imports for the current file
+  imports: ImportResult[] | null
+  // Cached scope analysis for the current file
+  scopeAnalysis: ReturnType<typeof analyze> | null
+} = {
+  imports: null,
+  scopeAnalysis: null,
+}
+
+// Tracks how many rules are currently running for the current file.
+//
+// Each rule increments this counter in `create()` and decrements it in `Program:exit`.
+// When counter reaches 0, all rules have finished for the file, and cache is cleared.
+// See `createRule` in `utils/index.ts` which injects `ruleStarted()` and `ruleFinished()` calls
+// into each rule automatically.
+//
+// As a safety net, a microtask is also queued to reset the caches.
+// This handles the case where a rule throws an error during linting, preventing `Program:exit` from firing
+// and leaving the counter stuck at a non-zero value.
+//
+// This scenario doesn't matter in ESLint CLI, because if an error is thrown during linting, the process exits.
+// But in language server, it does matter - language server catches the error and the process continues.
+// It also matters in tests. You don't want an error thrown in one test to affect the next test.
+// The `queueMicrotask` covers both these eventualities - it ensures the cache is reset before the next lint run.
+let numRulesRunning = 0
+
+let resetMicrotaskScheduled = false
+
+export function ruleStarted() {
+  numRulesRunning++
+  if (!resetMicrotaskScheduled) {
+    queueMicrotask(resetCacheMicrotask)
+    resetMicrotaskScheduled = true
+  }
+}
+
+export function ruleFinished() {
+  numRulesRunning--
+  if (numRulesRunning === 0) {
+    resetCache()
+  }
+}
+
+function resetCache() {
+  cache.imports = null
+  cache.scopeAnalysis = null
+}
+
+function resetCacheMicrotask() {
+  resetCache()
+  numRulesRunning = 0
+  resetMicrotaskScheduled = false
+}

--- a/plugin/src/utils/helpers.ts
+++ b/plugin/src/utils/helpers.ts
@@ -2,6 +2,7 @@ import type { RuleContext } from '@typescript-eslint/utils/ts-eslint'
 import type { TSESTree } from '@typescript-eslint/utils'
 import { analyze } from '@typescript-eslint/scope-manager'
 import { type ImportResult, syncAction } from '.'
+import { cache } from './cache'
 import {
   isCallExpression,
   isIdentifier,
@@ -19,50 +20,6 @@ import {
   type Node,
 } from './nodes'
 import type { DeprecatedToken } from './worker'
-
-// Tracks how many rules are currently running for the current file.
-//
-// Each rule increments this in `create()` and decrements it in `Program:exit`.
-// When counter reaches 0, all rules have finished for the file, and caches are cleared.
-// See `createRule` in `utils/index.ts` which injects `ruleStarted()` and `ruleFinished()` calls
-// into each rule automatically.
-//
-// As a safety net, a microtask is also queued to reset the caches.
-// This handles the case where a rule throws an error during linting, preventing `Program:exit` from firing
-// and leaving the counter stuck at a non-zero value.
-//
-// This scenario doesn't matter in ESLint CLI, because if an error is thrown during linting, the process exits.
-// But in language server, it does matter - language server catches the error and the process continues.
-// It also matters in tests. You don't want an error thrown in one test to affect the next test.
-// The `queueMicrotask` covers both these eventualities - it ensures the cache is reset before the next lint run.
-let numRulesRunning = 0
-let resetMicrotaskScheduled = false
-
-export function ruleStarted() {
-  numRulesRunning++
-  if (!resetMicrotaskScheduled) {
-    queueMicrotask(resetCachesMicrotask)
-    resetMicrotaskScheduled = true
-  }
-}
-
-export function ruleFinished() {
-  numRulesRunning--
-  if (numRulesRunning === 0) {
-    resetCaches()
-  }
-}
-
-function resetCaches() {
-  cachedImports = null
-  cachedScopeAnalysis = null
-}
-
-function resetCachesMicrotask() {
-  resetCaches()
-  numRulesRunning = 0
-  resetMicrotaskScheduled = false
-}
 
 export const getAncestor = <N extends Node>(ofType: (node: Node) => node is N, for_: Node): N | undefined => {
   let current: Node | undefined = for_.parent
@@ -121,16 +78,13 @@ const _getImports = (context: RuleContext<any, any>) => {
   return imports
 }
 
-// Cached imports for the current file. Cleared after linting each file (see `ruleFinished` above).
-let cachedImports: ImportResult[] | null = null
-
 export const getImports = (context: RuleContext<any, any>) => {
-  if (cachedImports) {
-    return cachedImports
+  if (cache.imports) {
+    return cache.imports
   }
   const imports = _getImports(context)
   const filteredImports = imports.filter((imp) => syncAction('matchImports', getSyncOpts(context), imp))
-  cachedImports = filteredImports
+  cache.imports = filteredImports
   return filteredImports
 }
 
@@ -150,9 +104,6 @@ export const isPandaIsh = (name: string, context: RuleContext<any, any>) => {
   return syncAction('matchFile', getSyncOpts(context), name, imports)
 }
 
-// Cached scope analysis for the current file. Cleared after linting each file (see `ruleFinished` above).
-let cachedScopeAnalysis: ReturnType<typeof analyze> | null = null
-
 const findDeclaration = (name: string, context: RuleContext<any, any>) => {
   try {
     const src = context.sourceCode
@@ -163,13 +114,13 @@ const findDeclaration = (name: string, context: RuleContext<any, any>) => {
     }
 
     let scope: ReturnType<typeof analyze>
-    if (cachedScopeAnalysis) {
-      scope = cachedScopeAnalysis
+    if (cache.scopeAnalysis) {
+      scope = cache.scopeAnalysis
     } else {
       scope = analyze(src.ast as TSESTree.Node, {
         sourceType: 'module',
       })
-      cachedScopeAnalysis = scope
+      cache.scopeAnalysis = scope
     }
 
     const decl = scope.variables

--- a/plugin/src/utils/helpers.ts
+++ b/plugin/src/utils/helpers.ts
@@ -20,6 +20,50 @@ import {
 } from './nodes'
 import type { DeprecatedToken } from './worker'
 
+// Tracks how many rules are currently running for the current file.
+//
+// Each rule increments this in `create()` and decrements it in `Program:exit`.
+// When counter reaches 0, all rules have finished for the file, and caches are cleared.
+// See `createRule` in `utils/index.ts` which injects `ruleStarted()` and `ruleFinished()` calls
+// into each rule automatically.
+//
+// As a safety net, a microtask is also queued to reset the caches.
+// This handles the case where a rule throws an error during linting, preventing `Program:exit` from firing
+// and leaving the counter stuck at a non-zero value.
+//
+// This scenario doesn't matter in ESLint CLI, because if an error is thrown during linting, the process exits.
+// But in language server, it does matter - language server catches the error and the process continues.
+// It also matters in tests. You don't want an error thrown in one test to affect the next test.
+// The `queueMicrotask` covers both these eventualities - it ensures the cache is reset before the next lint run.
+let numRulesRunning = 0
+let resetMicrotaskScheduled = false
+
+export function ruleStarted() {
+  numRulesRunning++
+  if (!resetMicrotaskScheduled) {
+    queueMicrotask(resetCachesMicrotask)
+    resetMicrotaskScheduled = true
+  }
+}
+
+export function ruleFinished() {
+  numRulesRunning--
+  if (numRulesRunning === 0) {
+    resetCaches()
+  }
+}
+
+function resetCaches() {
+  cachedImports = null
+  cachedScopeAnalysis = null
+}
+
+function resetCachesMicrotask() {
+  resetCaches()
+  numRulesRunning = 0
+  resetMicrotaskScheduled = false
+}
+
 export const getAncestor = <N extends Node>(ofType: (node: Node) => node is N, for_: Node): N | undefined => {
   let current: Node | undefined = for_.parent
   while (current) {
@@ -77,16 +121,16 @@ const _getImports = (context: RuleContext<any, any>) => {
   return imports
 }
 
-// Caching imports per context to avoid redundant computations
-const importsCache = new WeakMap<RuleContext<any, any>, ImportResult[]>()
+// Cached imports for the current file. Cleared after linting each file (see `ruleFinished` above).
+let cachedImports: ImportResult[] | null = null
 
 export const getImports = (context: RuleContext<any, any>) => {
-  if (importsCache.has(context)) {
-    return importsCache.get(context)!
+  if (cachedImports) {
+    return cachedImports
   }
   const imports = _getImports(context)
   const filteredImports = imports.filter((imp) => syncAction('matchImports', getSyncOpts(context), imp))
-  importsCache.set(context, filteredImports)
+  cachedImports = filteredImports
   return filteredImports
 }
 
@@ -106,7 +150,8 @@ export const isPandaIsh = (name: string, context: RuleContext<any, any>) => {
   return syncAction('matchFile', getSyncOpts(context), name, imports)
 }
 
-const scopeAnalysisCache = new WeakMap<object, ReturnType<typeof analyze>>()
+// Cached scope analysis for the current file. Cleared after linting each file (see `ruleFinished` above).
+let cachedScopeAnalysis: ReturnType<typeof analyze> | null = null
 
 const findDeclaration = (name: string, context: RuleContext<any, any>) => {
   try {
@@ -117,12 +162,14 @@ const findDeclaration = (name: string, context: RuleContext<any, any>) => {
       return undefined
     }
 
-    let scope = scopeAnalysisCache.get(src)
-    if (!scope) {
+    let scope: ReturnType<typeof analyze>
+    if (cachedScopeAnalysis) {
+      scope = cachedScopeAnalysis
+    } else {
       scope = analyze(src.ast as TSESTree.Node, {
         sourceType: 'module',
       })
-      scopeAnalysisCache.set(src, scope)
+      cachedScopeAnalysis = scope
     }
 
     const decl = scope.variables

--- a/plugin/src/utils/index.ts
+++ b/plugin/src/utils/index.ts
@@ -3,11 +3,41 @@ import { createSyncFn } from 'synckit'
 import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import type { run } from './worker'
+import { ruleStarted, ruleFinished } from './helpers'
 
 // Rule creator
-export const createRule = ESLintUtils.RuleCreator(
+const _createRule = ESLintUtils.RuleCreator(
   (name) => `https://github.com/chakra-ui/eslint-plugin-panda/blob/main/docs/rules/${name}.md`,
 )
+
+// Wraps the base rule creator to track how many rules are running.
+// Each rule increments a counter in `create()` and decrements it in `Program:exit`.
+// When the counter reaches 0 (all rules have finished for the current file), caches are cleared.
+// This ensures cached data is never stale across files, without relying on WeakMap identity
+// (which doesn't work in Oxlint where context objects are reused).
+export const createRule: typeof _createRule = (...args) => {
+  const rule = _createRule(...args)
+  const originalCreate = rule.create
+
+  rule.create = (context) => {
+    ruleStarted()
+    const visitor = originalCreate(context)
+
+    const existingExit = visitor['Program:exit']
+    if (existingExit) {
+      visitor['Program:exit'] = (node) => {
+        existingExit(node)
+        ruleFinished()
+      }
+    } else {
+      visitor['Program:exit'] = (_node) => ruleFinished()
+    }
+
+    return visitor
+  }
+
+  return rule
+}
 
 // Define Rule type explicitly
 export type Rule = ReturnType<typeof createRule>

--- a/plugin/src/utils/index.ts
+++ b/plugin/src/utils/index.ts
@@ -3,7 +3,7 @@ import { createSyncFn } from 'synckit'
 import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import type { run } from './worker'
-import { ruleStarted, ruleFinished } from './helpers'
+import { ruleStarted, ruleFinished } from './cache'
 
 // Rule creator
 const _createRule = ESLintUtils.RuleCreator(


### PR DESCRIPTION
Alternative to #308.

Same as #308, this removes the `WeakMap` caches `importsCache` and `scopeAnalysisCache`, and:

1. Replaces them with a faster mechanism.
2. Makes `importsCache` be shared across all rules (perf improvement).

This PR has the same goal, but uses a different mechanism.

It alters `createRule` which is used to wrap every rule to:

1. Add a call to `ruleStarted()` to the start of `create` (start of linting a file).
2. Add a call to `ruleFinished()` at end of linting in `Program:exit` (end of linting a file).

`ruleStarted()` increments a `numRulesRunning` counter, `ruleFinished()` decrements it. When the counter reaches zero, all rules have finished linting the file, and the caches are cleared.

This version more robustly answers the critique posed in https://github.com/chakra-ui/eslint-plugin-panda/pull/308#discussion_r2891784606. It doesn't rely on assumption that language servers lint each file in a separate micro-tick (even though that's a safe assumption), and it will continue to work if this plugin decides to add auto-fixes to any rules in future.

#308 is a bit more self-contained, but this version IMO is easier to reason about (which is usually a good thing!)